### PR TITLE
Fix 'open in Finder' for Windows

### DIFF
--- a/src/models/Project.js
+++ b/src/models/Project.js
@@ -84,7 +84,11 @@ export default types
         }
       },
       openDir: () => {
-        spawn('open', [self.path]);
+        if (process.platform === 'darwin') { 
+          spawn('open', [self.path]);
+        } else if (process.platform === 'win32') {
+          spawn('explorer', [self.path]);
+        }
       },
       build: () => {
         self.runScript('build');

--- a/src/models/Project.js
+++ b/src/models/Project.js
@@ -84,11 +84,8 @@ export default types
         }
       },
       openDir: () => {
-        if (process.platform === 'darwin') { 
-          spawn('open', [self.path]);
-        } else if (process.platform === 'win32') {
-          spawn('explorer', [self.path]);
-        }
+        const shell = window.require('electron').shell;
+        shell.openExternal(self.path);
       },
       build: () => {
         self.runScript('build');


### PR DESCRIPTION
As issued in #40 [here](https://github.com/kitze/JSUI/issues/40#issuecomment-395860670) 'open in Finder' is obviously not working in Windows, so this might be necessary for usage on Windows. 
