### PR TITLE
feat (builds): Enable travis CI and build for Mac, Linux and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+osx_image: xcode8.3
+
+dist: trusty
+sudo: false
+
+language: node_js
+node_js: "10"
+
+env:
+  global:
+    - ELECTRON_CACHE=$HOME/.cache/electron
+    - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+
+os:
+  - linux
+  - osx
+
+cache:
+  yarn: true
+  directories:
+  - node_modules
+  - $HOME/.cache/electron
+  - $HOME/.cache/electron-builder
+  - $HOME/.npm/_prebuilds
+
+install:
+  - yarn install
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then CI=false yarn release; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CI=false yarn release -- --mac --win; fi
+
+deploy:
+  api_key: $GITHUB_API_KEY
+  provider: releases
+  file_glob: true
+  file: "dist/*"
+  skip_cleanup: true
+  on:
+    tags: false
+    repo: kitze/JSUI
+    branch: master 
+
+before_cache:
+  - rm -rf $HOME/.cache/electron-builder/wine

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CI=false yarn release -- --mac --win; fi
 
 deploy:
-  api_key: $GITHUB_API_KEY
+  api_key: $GH_TOKEN
   provider: releases
   file_glob: true
   file: "dist/*"


### PR DESCRIPTION
Hey,

I saw you had an issue #5 to add Travis CI for automated builds. I also see another PR here by @rakannimer for this. 

I was playing around with this over the weekend to get builds working for Windows, and have an addition to the other PR here, that you guys can look at and see if its something you want to adopt.

I added a Travis CI setup to build for Mac, Windows and Linux, and deploy the packages to Github Releases. The configuration I'm adding here runs 2 Travis CI builds for a push on master, one running MacOs to build the mac and windows packages, and the other running Linux to generate the Linux package. When the builds successfully complete, a new draft release will be created with the 3 packages, and then this can be published from Github to make it available.

If you want to test this, you will need to add `GH_TOKEN` as an `environment variable` in Travis CI, which can be generated following [these steps](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).

[Example release](https://github.com/david-daly/JSUI/releases/tag/v0.0.17-TEST):
![image](https://user-images.githubusercontent.com/1348165/41511268-720c04a6-726b-11e8-9b69-611b2d1f2edc.png)

[Travis CI Build](https://travis-ci.org/david-daly/JSUI)


Feel free to add comments or close this PR if you don't like this approach, its just something I was playing with recently and thought might be useful. Thanks!