### PR TITLE
Update release command for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ install:
   - yarn install
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then CI=false yarn release; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CI=false yarn release -- --mac --win; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then CI=false yarn electron:release; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CI=false yarn electron:release -- --mac --win; fi
 
 deploy:
   api_key: $GH_TOKEN


### PR DESCRIPTION
Update release command for TravisCI from `release` to `electron:release` as it was changed recently in the `package.json` file before the PR that added this configuration for Travis CI (#101) was merged.