### PR TITLE
Changed getHttpsGitURL '.git' replace from substr to regex

### DIFF
--- a/src/utils/string-utils.js
+++ b/src/utils/string-utils.js
@@ -10,7 +10,7 @@ export const getHttpsGitURL = url => {
     return url
       .replace(':', '/')
       .replace('git@', 'https://')
-      .replace('.git', '');
+      .replace(/.git([^.git]*)$/, '');
   }
   return url;
 };


### PR DESCRIPTION
Hey there,

Noticed a bug where git urls containing the string `.git` would not parse correctly when importing a project. An example of this causing errors is for repos related to github pages for the url, example `https://github.com/colinkey/colinkey.github.io.git`. Importing into JSUI removes the first instance of .git and stores the url as `https://github.com/colinkey/colinkeyhub.io.git`.

This PR updates the getHttpsGitURL function to look for a regex expression that will only replace the last instance of `.git` to trim the url if `.git` is present.

Thanks! 