### PR TITLE
CSS-to-JS fixes/improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.test.local
 .env.production.local
 
+package-lock.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "rttr": "^1.0.0",
     "styles-debugger": "^1.0.0",
     "sweetalert2": "^7.19.1",
+    "transform-css-to-js": "^0.1.1",
     "update-electron-app": "^1.2.0",
     "uuid": "^3.2.1",
     "webpack": "^4.10.2",

--- a/src/components/CssToJsConverter/styles.js
+++ b/src/components/CssToJsConverter/styles.js
@@ -9,6 +9,9 @@ export const CssToJsConverter = emotion.div({
 });
 
 export const Textarea = emotion.textarea({
+  fontFamily: 'monospace',
+  letterSpacing: '0.5px',
+  lineHeight: '1.4',
   height: '100%',
   flex: 1,
   border: `1px solid ${whiteish(0.1)}`,
@@ -18,7 +21,7 @@ export const Textarea = emotion.textarea({
   borderRadius: 3,
   padding: 7,
   transition: 'all 150ms linear',
-  '&::placeholder':{
+  '&::placeholder': {
     color: whiteish(0.5)
   },
   '&:focus': {

--- a/src/utils/css-to-js.js
+++ b/src/utils/css-to-js.js
@@ -4,7 +4,7 @@ export default input => {
   // in case of invalid input, output the error
   try {
     const jsString = cssToJS(input);
-    const formatted = correctSpacing(jsString);
+    const formatted = cleanOutput(jsString);
     return output(formatted);
   } catch (error) {
     return error.toString();
@@ -16,8 +16,8 @@ const output = input => {
   return input.replace(/\s/g, '') === '{}' ? '' : input;
 };
 
-const correctSpacing = target => {
-  // remove weird spacing and give separator lines
+const cleanOutput = target => {
+  // remove weird spacing, give separator lines and remove comments
   return target
     .replace(/^\s\s\/\/.*\n/gm, '')
     .replace(/{\n/, '{')

--- a/src/utils/css-to-js.js
+++ b/src/utils/css-to-js.js
@@ -1,14 +1,23 @@
 import cssToJS from 'transform-css-to-js';
 
 export default input => {
+  // in case of invalid input, output the error
   try {
-    return correctSpacing(cssToJS(input));
+    const jsString = cssToJS(input);
+    const formatted = correctSpacing(jsString);
+    return output(formatted);
   } catch (error) {
     return error.toString();
   }
 };
 
+const output = input => {
+  // default to empty string so that placeholder shows
+  return input.replace(/\s/g, '') === '{}' ? '' : input;
+};
+
 const correctSpacing = target => {
+  // remove weird spacing and give separator lines
   return target
     .replace(/{\n/, '{')
     .replace(/,\n/gm, ',\n\n')

--- a/src/utils/css-to-js.js
+++ b/src/utils/css-to-js.js
@@ -1,7 +1,16 @@
-export default input =>
-  input
-    .replace(/-([a-z])/g, g => g[1].toUpperCase())
-    .replace(/: (.*?);/g, ": '$1',")
-    .replace(/\n *?(\w)/g, '\n$1')
-    .replace(/\n{2,}/g, '\n')
-    .replace(/'(-?\d+)px'/g, '$1');
+import cssToJS from 'transform-css-to-js';
+
+export default input => {
+  try {
+    return correctSpacing(cssToJS(input));
+  } catch (error) {
+    return error.toString();
+  }
+};
+
+const correctSpacing = target => {
+  return target
+    .replace(/{\n/, '{')
+    .replace(/,\n/gm, ',\n\n')
+    .replace(/^\s{6,}/gm, '    ');
+};

--- a/src/utils/css-to-js.js
+++ b/src/utils/css-to-js.js
@@ -19,6 +19,7 @@ const output = input => {
 const correctSpacing = target => {
   // remove weird spacing and give separator lines
   return target
+    .replace(/^\s\s\/\/.*\n/gm, '')
     .replace(/{\n/, '{')
     .replace(/,\n/gm, ',\n\n')
     .replace(/^\s{6,}/gm, '    ');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,6 +3251,10 @@ css-animation@^1.3.2:
     babel-runtime "6.x"
     component-classes "^1.2.5"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -3316,6 +3320,14 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.0.4:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.1.tgz#7f3f4c95de65501b8720c87bf0caf1f39073b88e"
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 css-vendor@^0.3.8:
   version "0.3.8"
@@ -4707,6 +4719,18 @@ fbjs@^0.8.1, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.5:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 fd-slicer@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
@@ -5070,6 +5094,10 @@ get-folder-size@^2.0.0:
   dependencies:
     gar "^1.0.2"
     tiny-each-async "2.0.3"
+
+get-own-enumerable-property-symbols@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -5976,7 +6004,7 @@ is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
 
-is-obj@^1.0.0:
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
@@ -6037,6 +6065,10 @@ is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
 
 is-relative@^1.0.0:
   version "1.0.0"
@@ -10007,6 +10039,14 @@ string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
+stringify-object@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.2.tgz#9853052e5a88fb605a44cd27445aa257ad7ffbcd"
+  dependencies:
+    get-own-enumerable-property-symbols "^2.0.1"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
+
 strip-ansi@3.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -10406,6 +10446,14 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
+transform-css-to-js@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/transform-css-to-js/-/transform-css-to-js-0.1.1.tgz#20fd40b137849555c063aa55f168680ad00724bb"
+  dependencies:
+    css-to-react-native "^2.0.4"
+    lodash "^4.17.4"
+    stringify-object "^3.2.0"
+
 tree-kill@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.0.tgz#5846786237b4239014f05db156b643212d4c6f36"
@@ -10455,7 +10503,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-ua-parser-js@^0.7.9:
+ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 


### PR DESCRIPTION
I present to you today, for your viewing pleasure, a pull request fixing the CSS-in-JS feature in JSUI and proposing a few tiny styling changes.

When I used the CSS-in-JS dialog, I found that it gives somewhat-janky output. (_See exhibit **A**_) This may be completely acceptable, given that the feature seems to be meant simply to format the declarations rather than providing a one-stop-shop for all of your CSS-in-JS transpilation needs. But I was not sure if it was a bug, so I sprang into action.

**Exhibit A:**

<img width="734" alt="screen shot 2018-06-30 at 2 56 07 am" src="https://user-images.githubusercontent.com/19484365/42123067-3e63c3e6-7c11-11e8-9d44-635c0a5977e0.png">

After my changes, this is how the output is formatted:

<img width="733" alt="screen shot 2018-06-30 at 2 56 19 am" src="https://user-images.githubusercontent.com/19484365/42123066-3e53b9e2-7c11-11e8-9d31-c81f57e21587.png">

I also found that the program would crash if the input was not valid and the parser threw an error, so I included minimal handling (a try/catch) that results in this when an error occurs in transpiling the CSS:

<img width="753" alt="screen shot 2018-06-30 at 2 27 36 am" src="https://user-images.githubusercontent.com/19484365/42123068-3e716758-7c11-11e8-8334-f58296fcc4b1.png">

As for the style changes, I don't know if they are too opinionated, but I felt that using a monospace font and applying a wee-bit of space really improved the experience, although I defaulted to simply `fontFamily: 'monospace'`, which is not necessarily a font to gawk at.

Alas, if this PR is to be approved, I'd also be more than happy to update the CSS-to-JS dialog's styles to be more consistent with other code-rendering components in the application.
